### PR TITLE
Wan VAE decode optimizations

### DIFF
--- a/distvae/models/layers/conv2d.py
+++ b/distvae/models/layers/conv2d.py
@@ -32,6 +32,7 @@ class PatchConv2d(nn.Conv2d, PatchConvMixin):
         dtype=None,
         block_size: Union[int, Tuple[int, int]] = 0,
         patch_dim: int = -2,
+        use_uniform_patch: bool = False,
     ) -> None:
 
         if isinstance(dilation, int):
@@ -44,6 +45,7 @@ class PatchConv2d(nn.Conv2d, PatchConvMixin):
         )
         self.block_size = block_size
         self.patch_dim = patch_dim
+        self.use_uniform_patch = use_uniform_patch
         super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             groups, bias, padding_mode, device, dtype)
@@ -76,7 +78,7 @@ class PatchConv2d(nn.Conv2d, PatchConvMixin):
                 patch_index,
                 group_world_size,
                 rank_in_group,
-            ) = self._multi_rank_metadata_and_halo(input)
+            ) = self._multi_rank_metadata_and_halo(input, self.use_uniform_patch)
             conv_res: Tensor
             padding = self._adjust_padding_for_patch(
                 self._reversed_padding_repeated_twice,

--- a/distvae/models/layers/conv3d.py
+++ b/distvae/models/layers/conv3d.py
@@ -49,6 +49,7 @@ class PatchConv3d(nn.Conv3d, PatchConvMixin):
         dtype=None,
         block_size: Union[int, Tuple[int, int, int]] = 0,
         patch_dim: int = -2,
+        use_uniform_patch: bool = False,
     ) -> None:
         """patch_dim: which spatial dim is split (F=-3/3, H=-2/2, W=-1/4). block_size: 0 => prefer direct path; int or (F,H,W) => chunked when any spatial > block_size."""
         if isinstance(dilation, int):
@@ -61,6 +62,8 @@ class PatchConv3d(nn.Conv3d, PatchConvMixin):
         )
         self.block_size = block_size
         self.patch_dim = patch_dim
+        self.use_uniform_patch = use_uniform_patch
+        self.halo_buffer = {}
         super().__init__(
             in_channels, out_channels, kernel_size, stride, padding, dilation,
             groups, bias, padding_mode, device, dtype)
@@ -95,7 +98,7 @@ class PatchConv3d(nn.Conv3d, PatchConvMixin):
                 patch_index,
                 group_world_size,
                 rank_in_group,
-            ) = self._multi_rank_metadata_and_halo(input)
+            ) = self._multi_rank_metadata_and_halo(input, self.use_uniform_patch, self.halo_buffer)
             conv_res: Tensor
             padding = self._adjust_padding_for_patch(
                 self._reversed_padding_repeated_twice,

--- a/distvae/models/layers/conv_mixin.py
+++ b/distvae/models/layers/conv_mixin.py
@@ -94,28 +94,25 @@ class PatchConvMixin:
             else self.stride
         )
         if use_uniform_patch:
-            if halo_buffer is None:
+
+            def _patch_index(patch_dim_size: int)
                 patch_list = [
                     torch.tensor(
-                        [input.shape[patch_dim]],
+                        [patch_dim_size],
                         dtype=torch.int64,
                         device=DistributedEnv.get_device()
                     ) for _ in range(group_world_size)
                 ]
-                patch_index = calc_patch_index(patch_list)
+                return calc_patch_index(patch_list)
+
+            if halo_buffer is None:
+                patch_index = _patch_index(input.shape[patch_dim])
             else:
                 key = ("patch_index", input.shape[patch_dim], torch.int64, DistributedEnv.get_device())
                 if key in halo_buffer:
                     patch_index = halo_buffer[key]
                 else:
-                    patch_list = [
-                        torch.tensor(
-                            [input.shape[patch_dim]],
-                            dtype=torch.int64,
-                            device=DistributedEnv.get_device()
-                        ) for _ in range(group_world_size)
-                    ]
-                    patch_index = calc_patch_index(patch_list)
+                    patch_index = _patch_index(input.shape[patch_dim])
                     halo_buffer[key] = patch_index
         else:
             patch_list = [

--- a/distvae/models/layers/conv_mixin.py
+++ b/distvae/models/layers/conv_mixin.py
@@ -95,7 +95,7 @@ class PatchConvMixin:
         )
         if use_uniform_patch:
 
-            def _patch_index(patch_dim_size: int)
+            def _patch_index(patch_dim_size: int):
                 patch_list = [
                     torch.tensor(
                         [patch_dim_size],

--- a/distvae/models/layers/conv_mixin.py
+++ b/distvae/models/layers/conv_mixin.py
@@ -59,7 +59,7 @@ class PatchConvMixin:
             spatial_sizes[i] <= block_size[i] for i in range(len(spatial_sizes))
         )
 
-    def _uniform_patch_index(self, patch_dim_size: int, group_world_size: int):
+    def _uniform_patch_index(self, t: torch.Tensor, group_world_size: int):
         """Calculate the patch index for a uniform patch.
 
         Args:
@@ -69,11 +69,12 @@ class PatchConvMixin:
         Returns:
             The patch index
         """
+        patch_dim = self.patch_dim if self.patch_dim >= 0 else t.ndim + self.patch_dim
         patch_list = [
             torch.tensor(
-                [patch_dim_size],
+                [t.shape[patch_dim]],
                 dtype=torch.int64,
-                device=DistributedEnv.get_device()
+                device=t.device
             ) for _ in range(group_world_size)
         ]
         return calc_patch_index(patch_list)
@@ -114,17 +115,17 @@ class PatchConvMixin:
         )
         if use_uniform_patch:
             if halo_buffer is None:
-                patch_index = self._uniform_patch_index(input.shape[patch_dim], group_world_size)
+                patch_index = self._uniform_patch_index(input, group_world_size)
             else:
-                key = ("patch_index", input.shape[patch_dim], torch.int64, DistributedEnv.get_device())
+                key = ("patch_index", input.shape[patch_dim], torch.int64, input.device)
                 if key in halo_buffer:
                     patch_index = halo_buffer[key]
                 else:
-                    patch_index = self._uniform_patch_index(input.shape[patch_dim], group_world_size)
+                    patch_index = self._uniform_patch_index(input, group_world_size)
                     halo_buffer[key] = patch_index
         else:
             patch_list = [
-                torch.zeros(1, dtype=torch.int64, device=DistributedEnv.get_device())
+                torch.zeros(1, dtype=torch.int64, device=input.device)
                 for _ in range(group_world_size)
             ]
             dist.all_gather(
@@ -132,7 +133,7 @@ class PatchConvMixin:
                 torch.tensor(
                     [input.shape[patch_dim]],
                     dtype=torch.int64,
-                    device=DistributedEnv.get_device(),
+                    device=input.device,
                 ),
                 group=DistributedEnv.get_vae_group(),
             )

--- a/distvae/models/layers/conv_mixin.py
+++ b/distvae/models/layers/conv_mixin.py
@@ -59,7 +59,12 @@ class PatchConvMixin:
             spatial_sizes[i] <= block_size[i] for i in range(len(spatial_sizes))
         )
 
-    def _multi_rank_metadata_and_halo(self, input: Tensor):
+    def _multi_rank_metadata_and_halo(
+        self,
+        input: Tensor,
+        use_uniform_patch: bool = False,
+        halo_buffer: dict = None
+    ):
         """All_gather patch sizes, compute patch_index and halo_width, exchange halos; return extended input and metadata.
 
         All-gathers each rank's patch size along the patch dimension, builds
@@ -88,20 +93,45 @@ class PatchConvMixin:
             if isinstance(self.stride, tuple)
             else self.stride
         )
-        patch_list = [
-            torch.zeros(1, dtype=torch.int64, device=DistributedEnv.get_device())
-            for _ in range(group_world_size)
-        ]
-        dist.all_gather(
-            patch_list,
-            torch.tensor(
-                [input.shape[patch_dim]],
-                dtype=torch.int64,
-                device=DistributedEnv.get_device(),
-            ),
-            group=DistributedEnv.get_vae_group(),
-        )
-        patch_index = calc_patch_index(patch_list)
+        if use_uniform_patch:
+            if halo_buffer is None:
+                patch_list = [
+                    torch.tensor(
+                        [input.shape[patch_dim]],
+                        dtype=torch.int64,
+                        device=DistributedEnv.get_device()
+                    ) for _ in range(group_world_size)
+                ]
+                patch_index = calc_patch_index(patch_list)
+            else:
+                key = ("patch_index", input.shape[patch_dim], torch.int64, DistributedEnv.get_device())
+                if key in halo_buffer:
+                    patch_index = halo_buffer[key]
+                else:
+                    patch_list = [
+                        torch.tensor(
+                            [input.shape[patch_dim]],
+                            dtype=torch.int64,
+                            device=DistributedEnv.get_device()
+                        ) for _ in range(group_world_size)
+                    ]
+                    patch_index = calc_patch_index(patch_list)
+                    halo_buffer[key] = patch_index
+        else:
+            patch_list = [
+                torch.zeros(1, dtype=torch.int64, device=DistributedEnv.get_device())
+                for _ in range(group_world_size)
+            ]
+            dist.all_gather(
+                patch_list,
+                torch.tensor(
+                    [input.shape[patch_dim]],
+                    dtype=torch.int64,
+                    device=DistributedEnv.get_device(),
+                ),
+                group=DistributedEnv.get_vae_group(),
+            )
+            patch_index = calc_patch_index(patch_list)
         halo_width = calc_halo_width(
             rank_in_group,
             patch_index,
@@ -141,6 +171,7 @@ class PatchConvMixin:
             next_top_halo_width,
             group_world_size,
             rank_in_group,
+            halo_buffer,
         )
         return (
             input,

--- a/distvae/models/layers/conv_mixin.py
+++ b/distvae/models/layers/conv_mixin.py
@@ -59,6 +59,25 @@ class PatchConvMixin:
             spatial_sizes[i] <= block_size[i] for i in range(len(spatial_sizes))
         )
 
+    def _uniform_patch_index(self, patch_dim_size: int, group_world_size: int):
+        """Calculate the patch index for a uniform patch.
+
+        Args:
+            patch_dim_size: The size of the patch dimension
+            group_world_size: The world size of the group
+
+        Returns:
+            The patch index
+        """
+        patch_list = [
+            torch.tensor(
+                [patch_dim_size],
+                dtype=torch.int64,
+                device=DistributedEnv.get_device()
+            ) for _ in range(group_world_size)
+        ]
+        return calc_patch_index(patch_list)
+
     def _multi_rank_metadata_and_halo(
         self,
         input: Tensor,
@@ -94,25 +113,14 @@ class PatchConvMixin:
             else self.stride
         )
         if use_uniform_patch:
-
-            def _patch_index(patch_dim_size: int):
-                patch_list = [
-                    torch.tensor(
-                        [patch_dim_size],
-                        dtype=torch.int64,
-                        device=DistributedEnv.get_device()
-                    ) for _ in range(group_world_size)
-                ]
-                return calc_patch_index(patch_list)
-
             if halo_buffer is None:
-                patch_index = _patch_index(input.shape[patch_dim])
+                patch_index = self._uniform_patch_index(input.shape[patch_dim], group_world_size)
             else:
                 key = ("patch_index", input.shape[patch_dim], torch.int64, DistributedEnv.get_device())
                 if key in halo_buffer:
                     patch_index = halo_buffer[key]
                 else:
-                    patch_index = _patch_index(input.shape[patch_dim])
+                    patch_index = self._uniform_patch_index(input.shape[patch_dim], group_world_size)
                     halo_buffer[key] = patch_index
         else:
             patch_list = [

--- a/distvae/models/layers/conv_utils.py
+++ b/distvae/models/layers/conv_utils.py
@@ -48,13 +48,6 @@ def calc_patch_index(patch_list: List[Tensor]):
         ],
         dim=0,
     ).cpu().tolist()
-#    height_index = []
-#    cur = 0
-#    for t in patch_list:
-#        height_index.append(cur)
-#        cur += t.item()
-#    height_index.append(cur)
-#    return height_index
 
 
 def calc_bottom_halo_width(rank, height_index, kernel_size, padding=0, stride=1):

--- a/distvae/models/layers/conv_utils.py
+++ b/distvae/models/layers/conv_utils.py
@@ -40,13 +40,21 @@ def calc_patch_index(patch_list: List[Tensor]):
         index of patch i; height_index[-1] is the total length. The first element
         is always 0.
     """
-    height_index = []
-    cur = 0
-    for t in patch_list:
-        height_index.append(cur)
-        cur += t.item()
-    height_index.append(cur)
-    return height_index
+    patch_list = torch.cat(patch_list, dim=0)
+    return torch.cat(
+        [
+            torch.zeros(1, device=patch_list.device, dtype=patch_list.dtype),
+            torch.cumsum(patch_list, dim=0),
+        ],
+        dim=0,
+    ).cpu().tolist()
+#    height_index = []
+#    cur = 0
+#    for t in patch_list:
+#        height_index.append(cur)
+#        cur += t.item()
+#    height_index.append(cur)
+#    return height_index
 
 
 def calc_bottom_halo_width(rank, height_index, kernel_size, padding=0, stride=1):
@@ -241,6 +249,7 @@ def exchange_halo(
     next_top_halo_width: int,
     group_world_size: int,
     rank_in_group: int,
+    halo_buffer: dict = None,
 ) -> Tensor:
     """Exchange halo regions with previous and next ranks; return extended local tensor.
 
@@ -277,9 +286,19 @@ def exchange_halo(
         )
         recv_shape = list(input.shape)
         recv_shape[patch_dim] = halo_width[0]
-        top_halo_recv = torch.empty(
-            recv_shape, dtype=input.dtype, device=DistributedEnv.get_device()
-        )
+        if halo_buffer is None:
+            top_halo_recv = torch.empty(
+                recv_shape, dtype=input.dtype, device=input.device
+            )
+        else:
+            key = ("top_recv", tuple(recv_shape), input.dtype, input.device)
+            if key in halo_buffer:
+                top_halo_recv = halo_buffer[key]
+            else:
+                top_halo_recv = torch.empty(
+                    recv_shape, dtype=input.dtype, device=input.device
+                )
+                halo_buffer[key] = top_halo_recv
         global_rank_of_prev = DistributedEnv.get_global_rank_from_group_rank(rank_in_group - 1)
         dist.recv(top_halo_recv, global_rank_of_prev, group=DistributedEnv.get_vae_group())
     if prev_bottom_halo_width > 0:
@@ -297,9 +316,19 @@ def exchange_halo(
         )
         recv_shape = list(input.shape)
         recv_shape[patch_dim] = halo_width[1]
-        bottom_halo_recv = torch.empty(
-            recv_shape, dtype=input.dtype, device=DistributedEnv.get_device()
-        )
+        if halo_buffer is None:
+            bottom_halo_recv = torch.empty(
+                recv_shape, dtype=input.dtype, device=input.device
+            )
+        else:
+            key = ("bottom_recv", tuple(recv_shape), input.dtype, input.device)
+            if key in halo_buffer:
+                bottom_halo_recv = halo_buffer[key]
+            else:
+                bottom_halo_recv = torch.empty(
+                    recv_shape, dtype=input.dtype, device=input.device
+                )
+                halo_buffer[key] = bottom_halo_recv
         if global_rank_of_next is None:
             global_rank_of_next = DistributedEnv.get_global_rank_from_group_rank(rank_in_group + 1)
         dist.recv(

--- a/distvae/modules/adapters/layers/conv_adapters.py
+++ b/distvae/modules/adapters/layers/conv_adapters.py
@@ -14,6 +14,7 @@ class Conv2dAdapter(nn.Module):
         *,
         block_size = 0,
         patch_dim: int = -2,
+        use_uniform_patch: bool = False,
     ):
         super().__init__()
         for i in conv2d.dilation:
@@ -32,6 +33,7 @@ class Conv2dAdapter(nn.Module):
             dtype=conv2d.weight.dtype,
             block_size=block_size,
             patch_dim=patch_dim,
+            use_uniform_patch=use_uniform_patch,
         )
         self.conv2d.weight.data = conv2d.weight.data
         if conv2d.bias is not None:
@@ -48,6 +50,7 @@ class Conv3dAdapter(nn.Module):
         *,
         block_size = 0,
         patch_dim: int = -2,
+        use_uniform_patch: bool = False,
     ):
         super().__init__()
         for i in conv3d.dilation:
@@ -66,6 +69,7 @@ class Conv3dAdapter(nn.Module):
             dtype=conv3d.weight.dtype,
             block_size=block_size,
             patch_dim=patch_dim,
+            use_uniform_patch=use_uniform_patch,
         )
         self.conv3d.weight.data = conv3d.weight.data
         if conv3d.bias is not None:
@@ -82,6 +86,7 @@ class WanCausalConv3dAdapter(nn.Module):
         *,
         block_size = 0,
         patch_dim: int = -2,
+        use_uniform_patch: bool = False,
     ):
         super().__init__()
         for i in causal_conv3d.dilation:
@@ -103,6 +108,7 @@ class WanCausalConv3dAdapter(nn.Module):
             dtype=causal_conv3d.weight.dtype,
             block_size=block_size,
             patch_dim=patch_dim,
+            use_uniform_patch=use_uniform_patch,
         )
         self.conv3d.weight.data = causal_conv3d.weight.data
         if causal_conv3d.bias is not None:

--- a/distvae/modules/adapters/midblock_adapters.py
+++ b/distvae/modules/adapters/midblock_adapters.py
@@ -5,14 +5,23 @@ from distvae.modules.adapters.layers.attn_adapters import WanAttentionBlockAdapt
 from distvae.modules.adapters.resnet_adapters import WanResidualBlockAdapter
 
 class WanMidBlockAdapter(nn.Module):
-    def __init__(self, wan_mid_block: WanMidBlock, conv_block_size = 0, patch_dim: int = -2):
+    def __init__(
+        self,
+        wan_mid_block: WanMidBlock,
+        conv_block_size = 0,
+        patch_dim: int = -2,
+        use_uniform_patch: bool = False,
+    ):
         super().__init__()
 
         assert isinstance(wan_mid_block, WanMidBlock), "WanMidBlockAdapter does not support mid block except WanMidBlock"
         self.mid_block = wan_mid_block
         self.mid_block.resnets = nn.ModuleList([
             WanResidualBlockAdapter(
-                resnet, conv_block_size=conv_block_size, patch_dim=patch_dim
+                resnet,
+                conv_block_size=conv_block_size,
+                patch_dim=patch_dim,
+                use_uniform_patch=use_uniform_patch,
             ) for resnet in wan_mid_block.resnets
         ])
         self.mid_block.attentions = nn.ModuleList([

--- a/distvae/modules/adapters/resnet_adapters.py
+++ b/distvae/modules/adapters/resnet_adapters.py
@@ -55,6 +55,7 @@ class WanResidualBlockAdapter(nn.Module):
         wan_residual_block: WanResidualBlock,
         conv_block_size = 0,
         patch_dim: int = -2,
+        use_uniform_patch: bool = False,
     ):
         super().__init__()
         assert isinstance(wan_residual_block, WanResidualBlock), (
@@ -62,10 +63,16 @@ class WanResidualBlockAdapter(nn.Module):
         )
         self.residual_block = wan_residual_block
         self.residual_block.conv1 = WanCausalConv3dAdapter(
-            wan_residual_block.conv1, block_size=conv_block_size, patch_dim=patch_dim
+            wan_residual_block.conv1,
+            block_size=conv_block_size,
+            patch_dim=patch_dim,
+            use_uniform_patch=use_uniform_patch
         )
         self.residual_block.conv2 = WanCausalConv3dAdapter(
-            wan_residual_block.conv2, block_size=conv_block_size, patch_dim=patch_dim
+            wan_residual_block.conv2,
+            block_size=conv_block_size,
+            patch_dim=patch_dim,
+            use_uniform_patch=use_uniform_patch
         )
 
     def forward(self, x, feat_cache=None, feat_idx=[0]):

--- a/distvae/modules/adapters/upsampling_adapters.py
+++ b/distvae/modules/adapters/upsampling_adapters.py
@@ -52,6 +52,7 @@ class WanResampleAdapter(nn.Module):
         wan_resample: WanResample,
         conv_block_size = 0,
         patch_dim: int = -2,
+        use_uniform_patch: bool = False,
     ):
         super().__init__()
         assert isinstance(wan_resample, WanResample), (
@@ -62,14 +63,22 @@ class WanResampleAdapter(nn.Module):
             raise ValueError("WanResampleAdapter does not support patch_dim F (-3); use H (-2) or W (-1).")
         if hasattr(wan_resample, "time_conv"):
             wan_resample.time_conv = WanCausalConv3dAdapter(
-                wan_resample.time_conv, block_size=conv_block_size, patch_dim=patch_dim
+                wan_resample.time_conv,
+                block_size=conv_block_size,
+                patch_dim=patch_dim,
+                use_uniform_patch=use_uniform_patch
         )
         if isinstance(wan_resample.resample, nn.Sequential):
             resample = []
             for layer in wan_resample.resample:
                 if isinstance(layer, nn.Conv2d):
                     resample.append(
-                        Conv2dAdapter(layer, block_size=conv_block_size, patch_dim=patch_dim)
+                        Conv2dAdapter(
+                            layer,
+                            block_size=conv_block_size,
+                            patch_dim=patch_dim,
+                            use_uniform_patch=use_uniform_patch
+                        )
                     )
                 else:
                     resample.append(layer)
@@ -87,6 +96,7 @@ class WanResidualUpBlockAdapter(nn.Module):
         wan_residual_up_block: WanResidualUpBlock,
         conv_block_size = 0,
         patch_dim: int = -2,
+        use_uniform_patch: bool = False,
     ):
         super().__init__()
         assert isinstance(wan_residual_up_block, WanResidualUpBlock), (
@@ -95,14 +105,20 @@ class WanResidualUpBlockAdapter(nn.Module):
         self.residual_up_block = wan_residual_up_block
         self.residual_up_block.resnets = nn.ModuleList([
             WanResidualBlockAdapter(
-                resnet, conv_block_size=conv_block_size, patch_dim=patch_dim)
-                for resnet in wan_residual_up_block.resnets
+                resnet,
+                conv_block_size=conv_block_size,
+                patch_dim=patch_dim,
+                use_uniform_patch=use_uniform_patch
+            ) for resnet in wan_residual_up_block.resnets
         ])
         if hasattr(wan_residual_up_block, "upsamplers"):
             if wan_residual_up_block.upsamplers is not None:
                 self.residual_up_block.upsamplers = nn.ModuleList([
                     WanResampleAdapter(
-                        upsampler, conv_block_size=conv_block_size, patch_dim=patch_dim
+                        upsampler,
+                        conv_block_size=conv_block_size,
+                        patch_dim=patch_dim,
+                        use_uniform_patch=use_uniform_patch
                     ) if isinstance(upsampler, WanResample) else upsampler
                     for upsampler in wan_residual_up_block.upsamplers
                 ])
@@ -111,7 +127,10 @@ class WanResidualUpBlockAdapter(nn.Module):
                 upsampler = wan_residual_up_block.upsampler
                 if isinstance(upsampler, WanResample):
                     self.residual_up_block.upsampler = WanResampleAdapter(
-                        upsampler, conv_block_size=conv_block_size, patch_dim=patch_dim
+                        upsampler,
+                        conv_block_size=conv_block_size,
+                        patch_dim=patch_dim,
+                        use_uniform_patch=use_uniform_patch,
                     )
 
     def forward(self, x, feat_cache=None, feat_idx=[0], first_chunk=False):
@@ -124,6 +143,7 @@ class WanUpBlockAdapter(nn.Module):
         wan_up_block: WanUpBlock,
         conv_block_size = 0,
         patch_dim: int = -2,
+        use_uniform_patch: bool = False,
     ):
         super().__init__()
         assert isinstance(wan_up_block, WanUpBlock), (
@@ -132,14 +152,20 @@ class WanUpBlockAdapter(nn.Module):
         self.up_block = wan_up_block
         self.up_block.resnets = nn.ModuleList([
             WanResidualBlockAdapter(
-                resnet, conv_block_size=conv_block_size, patch_dim=patch_dim)
-                for resnet in wan_up_block.resnets
+                resnet,
+                conv_block_size=conv_block_size,
+                patch_dim=patch_dim,
+                use_uniform_patch=use_uniform_patch,
+            ) for resnet in wan_up_block.resnets
         ])
         if hasattr(wan_up_block, "upsamplers"):
             if wan_up_block.upsamplers is not None:
                 self.up_block.upsamplers = nn.ModuleList([
                     WanResampleAdapter(
-                        upsampler, conv_block_size=conv_block_size, patch_dim=patch_dim
+                        upsampler,
+                        conv_block_size=conv_block_size,
+                        patch_dim=patch_dim,
+                        use_uniform_patch=use_uniform_patch,
                     ) if isinstance(upsampler, WanResample) else upsampler
                     for upsampler in wan_up_block.upsamplers
                 ])
@@ -148,7 +174,10 @@ class WanUpBlockAdapter(nn.Module):
                 upsampler = wan_up_block.upsampler
                 if isinstance(upsampler, WanResample):
                     self.up_block.upsampler = WanResampleAdapter(
-                        upsampler, conv_block_size=conv_block_size, patch_dim=patch_dim
+                        upsampler,
+                        conv_block_size=conv_block_size,
+                        patch_dim=patch_dim,
+                        use_uniform_patch=use_uniform_patch,
                     )
 
     def forward(self, x, feat_cache=None, feat_idx=[0], first_chunk=False):

--- a/distvae/modules/adapters/vae/decoder_adapters.py
+++ b/distvae/modules/adapters/vae/decoder_adapters.py
@@ -104,6 +104,7 @@ class WanDecoderAdapter(nn.Module):
         decoder: Decoder, 
         vae_group: ProcessGroup = None,
         *,
+        use_uniform_patch: bool = True,
         use_profiler: bool = False,
         verbose: bool = False,
         conv_block_size = 0,
@@ -117,10 +118,10 @@ class WanDecoderAdapter(nn.Module):
         DistributedEnv.set_patch_dim(patch_dim)
         self.decoder = decoder
         self.decoder.conv_in = WanCausalConv3dAdapter(
-            decoder.conv_in, block_size=conv_block_size, patch_dim=patch_dim
+            decoder.conv_in, block_size=conv_block_size, patch_dim=patch_dim, use_uniform_patch=use_uniform_patch
         )
         self.decoder.mid_block = WanMidBlockAdapter(
-            decoder.mid_block, conv_block_size=conv_block_size, patch_dim=patch_dim
+            decoder.mid_block, conv_block_size=conv_block_size, patch_dim=patch_dim, use_uniform_patch=use_uniform_patch
         )
         up_blocks = []
         for up_block in decoder.up_blocks:
@@ -129,7 +130,8 @@ class WanDecoderAdapter(nn.Module):
                     WanUpBlockAdapter(
                         up_block,
                         conv_block_size=conv_block_size,
-                        patch_dim=patch_dim
+                        patch_dim=patch_dim,
+                        use_uniform_patch=use_uniform_patch
                     )
                 )
             elif isinstance(up_block, WanResidualUpBlock):
@@ -137,15 +139,17 @@ class WanDecoderAdapter(nn.Module):
                     WanResidualUpBlockAdapter(
                         up_block,
                         conv_block_size=conv_block_size,
-                        patch_dim=patch_dim
+                        patch_dim=patch_dim,
+                        use_uniform_patch=use_uniform_patch
                     )
                 )                
         self.decoder.up_blocks = nn.ModuleList(up_blocks)
         self.decoder.conv_out = WanCausalConv3dAdapter(
-            decoder.conv_out, block_size=conv_block_size, patch_dim=patch_dim
+            decoder.conv_out, block_size=conv_block_size, patch_dim=patch_dim, use_uniform_patch=use_uniform_patch
         )
-        self.patchify = Patchify(patch_dim=patch_dim)
-        self.depatchify = DePatchify(patch_dim=patch_dim)
+        self.patchify = Patchify(patch_dim=patch_dim, use_uniform_patch=use_uniform_patch)
+        self.depatchify = DePatchify(patch_dim=patch_dim, use_uniform_patch=use_uniform_patch)
+        self.use_uniform_patch = use_uniform_patch
         self.use_profiler = use_profiler
         self.verbose = verbose
         self.vae_group = vae_group
@@ -158,11 +162,24 @@ class WanDecoderAdapter(nn.Module):
         first_chunk: bool = False,
         patchify: bool = True
     ):
+        if self.use_uniform_patch and not patchify:
+            raise ValueError("WanDecoderAdapter does not support use_uniform_patch for already patchified inputs.")
+
+        if self.use_uniform_patch:
+            patch_dim = self.patch_dim if self.patch_dim >= 0 else sample.ndim + self.patch_dim
+            patch_dim_size = sample.shape[patch_dim]
+
         if patchify:
             sample = self.patchify(sample)
-        sample = self.decoder(sample, feat_cache=feat_cache, feat_idx=feat_idx, first_chunk=first_chunk)
-        sample = self.depatchify(sample)
-        return sample
+        output = self.decoder(sample, feat_cache=feat_cache, feat_idx=feat_idx, first_chunk=first_chunk)
+        output = self.depatchify(output)
+
+        if self.use_uniform_patch:
+            group_world_size = DistributedEnv.get_group_world_size()
+            upsampling_factor = output.shape[patch_dim] // (sample.shape[patch_dim] * group_world_size)
+            output = output.narrow(patch_dim, 0, patch_dim_size * upsampling_factor)
+
+        return output
 
     def forward(
         self,

--- a/distvae/modules/patch_utils.py
+++ b/distvae/modules/patch_utils.py
@@ -42,17 +42,25 @@ class DePatchify(nn.Module):
         patch_dim = self.patch_dim if self.patch_dim >= 0 else patch_hidden_state.ndim + self.patch_dim
         if self.use_uniform_patch:
             patch_size_list = [
-                torch.tensor([patch_hidden_state.shape[patch_dim]], dtype=torch.int64, device=DistributedEnv.get_device())
+                torch.tensor(
+                    [patch_hidden_state.shape[patch_dim]],
+                    dtype=torch.int64,
+                    device=patch_hidden_state.device
+                )
                 for _ in range(self.group_world_size)
             ]
         else:
             patch_size_list = [
-                torch.empty([1], dtype=torch.int64, device=DistributedEnv.get_device())
+                torch.empty([1], dtype=torch.int64, device=patch_hidden_state.device)
                 for _ in range(self.group_world_size)
             ]
             dist.all_gather(
                 patch_size_list,
-                torch.tensor([patch_hidden_state.shape[patch_dim]], dtype=torch.int64, device=DistributedEnv.get_device()),
+                torch.tensor(
+                    [patch_hidden_state.shape[patch_dim]],
+                    dtype=torch.int64,
+                    device=patch_hidden_state.device
+                ),
                 group=DistributedEnv.get_vae_group()
             )
         hidden_state_shape = list(patch_hidden_state.shape)
@@ -60,7 +68,11 @@ class DePatchify(nn.Module):
         for i in range(self.group_world_size):
             hidden_state_shape[patch_dim] = patch_size_list[i].item()
             patch_hidden_state_list.append(
-                torch.empty(hidden_state_shape, dtype=patch_hidden_state.dtype, device=DistributedEnv.get_device())
+                torch.empty(
+                    hidden_state_shape,
+                    dtype=patch_hidden_state.dtype,
+                    device=patch_hidden_state.device
+                )
             )
         dist.all_gather(
             patch_hidden_state_list,

--- a/distvae/modules/patch_utils.py
+++ b/distvae/modules/patch_utils.py
@@ -20,6 +20,7 @@ class Patchify(nn.Module):
             patch_dim_size = hidden_state.shape[patch_dim]
             pad_size = 2 * [0] * hidden_state.ndim
             # remember that torch.pad operates on the last dimension first
+            # pad_size for patch_dim is the number of elements to pad to the next multiple of group_world_size
             pad_size[2 * (hidden_state.ndim - patch_dim - 1) + 1] = (
                 self.group_world_size - patch_dim_size % self.group_world_size
             ) % self.group_world_size

--- a/distvae/modules/patch_utils.py
+++ b/distvae/modules/patch_utils.py
@@ -1,42 +1,59 @@
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.distributed as dist
 
 from distvae.utils import DistributedEnv
 
 
 class Patchify(nn.Module):
-    def __init__(self, patch_dim: int = -2):
+    def __init__(self, patch_dim: int = -2, use_uniform_patch: bool = False):
         super().__init__()
         self.group_world_size = DistributedEnv.get_group_world_size()
         self.rank_in_vae_group = DistributedEnv.get_rank_in_vae_group()
         self.patch_dim = patch_dim
+        self.use_uniform_patch = use_uniform_patch
 
     def forward(self, hidden_state):
         patch_dim = self.patch_dim if self.patch_dim >= 0 else hidden_state.ndim + self.patch_dim
+        if self.use_uniform_patch:
+            patch_dim_size = hidden_state.shape[patch_dim]
+            pad_size = 2 * [0] * hidden_state.ndim
+            # remember that torch.pad operates on the last dimension first
+            pad_size[2 * (hidden_state.ndim - patch_dim - 1) + 1] = (
+                self.group_world_size - patch_dim_size % self.group_world_size
+            ) % self.group_world_size
+            hidden_state = F.pad(hidden_state, tuple(pad_size), mode='constant', value=0)
         chunks = torch.chunk(hidden_state, self.group_world_size, dim=patch_dim)
         return chunks[self.rank_in_vae_group].clone()
 
 
 class DePatchify(nn.Module):
-    def __init__(self, patch_dim: int = -2):
+    def __init__(self, patch_dim: int = -2, use_uniform_patch: bool = False):
         super().__init__()
         self.group_world_size = DistributedEnv.get_group_world_size()
         self.rank_in_vae_group = DistributedEnv.get_rank_in_vae_group()
         self.local_rank = DistributedEnv.get_local_rank()
         self.patch_dim = patch_dim
+        self.use_uniform_patch = use_uniform_patch
 
     def forward(self, patch_hidden_state):
         patch_dim = self.patch_dim if self.patch_dim >= 0 else patch_hidden_state.ndim + self.patch_dim
-        patch_size_list = [
-            torch.empty([1], dtype=torch.int64, device=DistributedEnv.get_device())
-            for _ in range(self.group_world_size)
-        ]
-        dist.all_gather(
-            patch_size_list,
-            torch.tensor([patch_hidden_state.shape[patch_dim]], dtype=torch.int64, device=DistributedEnv.get_device()),
-            group=DistributedEnv.get_vae_group()
-        )
+        if self.use_uniform_patch:
+            patch_size_list = [
+                torch.tensor([patch_hidden_state.shape[patch_dim]], dtype=torch.int64, device=DistributedEnv.get_device())
+                for _ in range(self.group_world_size)
+            ]
+        else:
+            patch_size_list = [
+                torch.empty([1], dtype=torch.int64, device=DistributedEnv.get_device())
+                for _ in range(self.group_world_size)
+            ]
+            dist.all_gather(
+                patch_size_list,
+                torch.tensor([patch_hidden_state.shape[patch_dim]], dtype=torch.int64, device=DistributedEnv.get_device()),
+                group=DistributedEnv.get_vae_group()
+            )
         hidden_state_shape = list(patch_hidden_state.shape)
         patch_hidden_state_list = []
         for i in range(self.group_world_size):


### PR DESCRIPTION
Optimizes Wan VAE decoder

#### Motivation

Present implementation has bottle-necks revealed by profiling and analysis of communication side. Getting rid of the bottle-necks and optimizing communication could save a considerable fraction of decode time still.

#### Tasks

Complete

- [x] Get rid of `patch_list` allgathers by padding patch dimension to a uniform number across ranks
- [x] Cache `patch_index` to avoid memory allocations and host-to-device synchronization points
to optimize VAE decode.

#### Tests

Running with the implemented optimizations saves ~0.5s compared to the prior code. Optimizations do not have impact on quality as shown below.

https://github.com/user-attachments/assets/c74e45d3-5f2b-43f1-9d4c-44817909f824

#### Other

Please squash merge