### PR TITLE
Support iris ring attention for Wan

### DIFF
--- a/distvae/models/layers/wan/ringattentionblock.py
+++ b/distvae/models/layers/wan/ringattentionblock.py
@@ -1,0 +1,75 @@
+import os
+import sys
+
+import iris
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from distvae.utils import DistributedEnv
+
+iris_pkg_dir = os.path.dirname(iris.__file__)
+sys.path.append(os.path.join(os.path.dirname(iris_pkg_dir), "examples", "32_ring_attention"))
+from ring_attention_layer import RingAttention
+
+
+class WanRingAttentionBlock(torch.nn.Module):
+    """WanRingAttentionBlock is a wrapper for the RingAttention layer from the Iris package.
+    """
+
+    def __init__(
+        self,
+        module: nn.Module,
+        patch_dim: int = -2,
+    ) -> None:
+        super().__init__()
+        self.norm = module.norm
+        self.to_qkv = module.to_qkv
+        self.proj = module.proj
+
+        self.shmem = iris.iris()
+        self.attn = RingAttention(
+            self.shmem,
+            num_heads=1,
+            head_dim=384,
+            causal=False,
+            scale=384**-0.5,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        identity = x
+        batch_size, channels, time, height, width = x.size()
+
+        x = x.permute(0, 2, 1, 3, 4).reshape(batch_size * time, channels, height, width)
+        x = self.norm(x)
+
+        # compute query, key, value
+        qkv = self.to_qkv(x)
+        qkv = qkv.reshape(batch_size * time, 1, channels * 3, -1)
+        qkv = qkv.permute(0, 1, 3, 2).contiguous()
+        q, k, v = qkv.chunk(3, dim=-1)
+
+        # apply attention
+        head_dim = 384
+        seqlen_pad_size = (64 - (height * width) % 64) % 64
+        q, k, v= (
+            F.pad(
+                t,
+                (0, 0, 0, seqlen_pad_size, 0, 0, 0, 0),
+                mode='constant',
+                value=0,
+            ).permute(2, 0, 1, 3).reshape(-1, batch_size * time, head_dim)
+            for t in [q, k, v]
+        )
+        x = self.attn(q, k, v)
+        x = torch.narrow(x, 0, 0, height * width)
+        x = x.permute(1, 2, 0).reshape(batch_size * time, channels, height, width)
+
+        # output projection
+        x = self.proj(x)
+
+        # Reshape back: [(b*t), c, h, w] -> [b, c, t, h, w]
+        x = x.view(batch_size, time, channels, height, width)
+        x = x.permute(0, 2, 1, 3, 4)
+
+        return x + identity

--- a/distvae/modules/adapters/layers/attn_adapters.py
+++ b/distvae/modules/adapters/layers/attn_adapters.py
@@ -6,7 +6,6 @@ import torch.nn as nn
 
 from distvae.utils import DistributedEnv
 
-
 class WanAttentionBlockAdapter(torch.nn.Module):
     """Runs attention on the full sequence by gathering along the patch dim, then narrows back to the local patch.
 

--- a/distvae/modules/adapters/midblock_adapters.py
+++ b/distvae/modules/adapters/midblock_adapters.py
@@ -1,7 +1,7 @@
 import torch.nn as nn
 from diffusers.models.autoencoders.autoencoder_kl_wan import WanMidBlock
 
-from distvae.modules.adapters.layers.attn_adapters import WanAttentionBlockAdapter
+from distvae.models.layers.wan.ringattentionblock import WanRingAttentionBlock
 from distvae.modules.adapters.resnet_adapters import WanResidualBlockAdapter
 
 class WanMidBlockAdapter(nn.Module):
@@ -25,7 +25,7 @@ class WanMidBlockAdapter(nn.Module):
             ) for resnet in wan_mid_block.resnets
         ])
         self.mid_block.attentions = nn.ModuleList([
-            WanAttentionBlockAdapter(attn, patch_dim=patch_dim)
+            WanRingAttentionBlock(attn, patch_dim=patch_dim)
             for attn in wan_mid_block.attentions
         ])
 


### PR DESCRIPTION
Integrate Iris ring attention into the Wan VAE mid block and make the Iris example import path portable.

## Changes

- **Add `WanRingAttentionBlock`** (`distvae/models/layers/wan/ringattentionblock.py`): a wrapper around Iris's `RingAttention` that reuses the original block's `norm`, `to_qkv`, and `proj`, pads the sequence to a multiple of 64, runs ring attention, and narrows back to the real sequence length.
- **Wire it into `WanMidBlockAdapter`** (`midblock_adapters.py`): mid-block attentions are now replaced with `WanRingAttentionBlock`.
- **Resolve the Iris examples path dynamically**: replace the hardcoded `/home/code/temporary/iris/...` path with one derived from `iris.__file__`, so it works across machines/checkouts.
- **Slim down `attn_adapters.py`**: the ring-attention adapter moved out into its own module, leaving `WanAttentionBlockAdapter` (all-gather based) in place.

## Notes

The dynamic path assumes a source checkout of Iris where `examples/32_ring_attention` is a sibling of the package; it won't resolve for a plain site-packages install.